### PR TITLE
Add index.json for asset tracking and index.html catalog

### DIFF
--- a/.github/scripts/process_file.py
+++ b/.github/scripts/process_file.py
@@ -6,31 +6,83 @@ import subprocess
 import re
 from pathlib import Path
 import html
+import json
 
-# Define constants for output directories and flag file location
+# Define constants for output directories and index file location
 BASE_OUTPUT_DIR = Path("processed_media")
 DESCRIPTION_DIR = BASE_OUTPUT_DIR / "descriptions"
 IMAGE_DIR = BASE_OUTPUT_DIR / "images"
 VIDEO_DIR = BASE_OUTPUT_DIR / "videos"
 HTML_DIR = BASE_OUTPUT_DIR / "html"
-FLAG_DIR = Path("processed_flags")
+INDEX_FILE_PATH = Path("index.json") # Root level index.json
 
 # Define processing step keywords
 STEP_GEMINI_DESCRIPTION = "gemini_description"
 STEP_IMAGE_CONVERSION = "image_conversion"
 STEP_HTML_GENERATION = "html_generation"
 STEP_VIDEO_CONVERSION = "video_conversion"
-BASE_NAME_FLAG_PREFIX = "base_name:"
+# BASE_NAME_FLAG_PREFIX = "base_name:" # No longer needed
 
 # Ensure output directories exist (idempotent)
 DESCRIPTION_DIR.mkdir(parents=True, exist_ok=True)
 IMAGE_DIR.mkdir(parents=True, exist_ok=True)
 VIDEO_DIR.mkdir(parents=True, exist_ok=True)
 HTML_DIR.mkdir(parents=True, exist_ok=True)
-FLAG_DIR.mkdir(parents=True, exist_ok=True)
+# FLAG_DIR.mkdir(parents=True, exist_ok=True) # No longer needed
 
 def log_message(message, level="INFO"):
     print(f"[{level}] {message}", file=sys.stderr if level == "ERROR" else sys.stdout)
+
+# --- Start of new JSON handling functions ---
+def load_index_data(index_path: Path) -> list[dict]:
+    """Loads index.json if it exists, returns an empty list otherwise."""
+    if index_path.exists():
+        try:
+            with open(index_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                if isinstance(data, list):
+                    return data
+                log_message(f"Warning: index.json content is not a list. Starting fresh.", level="WARNING")
+                return []
+        except json.JSONDecodeError:
+            log_message(f"Error decoding index.json. Starting fresh.", level="ERROR")
+            return []
+    return []
+
+def save_index_data(index_path: Path, data: list[dict]):
+    """Saves the data to index.json."""
+    try:
+        with open(index_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=4)
+        log_message(f"Saved data to {index_path}")
+    except IOError as e:
+        log_message(f"Error saving index data to {index_path}: {e}", level="ERROR")
+
+
+def find_asset_in_index(index_data: list[dict], file_hash: str) -> dict | None:
+    """Finds an asset by its source hash."""
+    for asset in index_data:
+        if asset.get("source_hash") == file_hash:
+            return asset
+    return None
+
+def update_asset_in_index(index_data: list[dict], asset_data: dict) -> list[dict]:
+    """Updates an existing asset or adds a new one. Returns the modified index_data."""
+    source_hash = asset_data.get("source_hash")
+    if not source_hash:
+        log_message("Error: Asset data must have a 'source_hash' to be updated in index.", level="ERROR")
+        return index_data # Return original data if no hash
+
+    for i, existing_asset in enumerate(index_data):
+        if existing_asset.get("source_hash") == source_hash:
+            index_data[i] = asset_data
+            return index_data
+    # If not found, add as new asset
+    index_data.append(asset_data)
+    return index_data
+
+# --- End of new JSON handling functions ---
+
 
 def main():
     parser = argparse.ArgumentParser(description="Process a single media file.")
@@ -44,31 +96,45 @@ def main():
 
     log_message(f"Starting processing for file: {args.input_file} (hash: {args.file_hash})")
 
-    # Further logic will be added here in subsequent steps.
-    # For now, just demonstrate argument parsing.
-    log_message(f"Input File: {args.input_file}")
-    log_message(f"File Hash: {args.file_hash}")
-    log_message(f"GitHub Repository: {args.github_repository}")
-    log_message(f"GitHub Ref for Raw URL: {args.github_ref_for_raw_url}")
-    # Gemini API key is sensitive, so avoid logging it directly unless for specific debug and ensure it's not committed.
-    # log_message(f"Gemini API Key: {'*' * len(args.gemini_api_key) if args.gemini_api_key else 'Not provided'}")
+    # Load existing index data
+    index_data = load_index_data(INDEX_FILE_PATH)
+    current_asset_data = find_asset_in_index(index_data, args.file_hash)
+
+    if current_asset_data is None:
+        log_message(f"No existing entry found for hash {args.file_hash}. Creating new entry.")
+        current_asset_data = {
+            "source_file_path": args.input_file,
+            "source_hash": args.file_hash,
+            "base_name": None,
+            "description_markdown_path": None,
+            "processed_steps": [],
+            "outputs": {
+                "type": None, # Will be 'image' or 'video'
+                "html_page_path": None,
+                "image_files": [],
+                "video_files": []
+            },
+            "raw_content_url_prefix": f"https://raw.githubusercontent.com/{args.github_repository}/{args.github_ref_for_raw_url}/"
+        }
+    else:
+        log_message(f"Found existing entry for hash {args.file_hash}.")
+        # Ensure essential keys exist if loading an older or incomplete entry
+        current_asset_data.setdefault("processed_steps", [])
+        current_asset_data.setdefault("outputs", {
+            "type": None, "html_page_path": None, "image_files": [], "video_files": []
+        })
+        current_asset_data["raw_content_url_prefix"] = f"https://raw.githubusercontent.com/{args.github_repository}/{args.github_ref_for_raw_url}/" # Update if needed
+        current_asset_data["source_file_path"] = args.input_file # Update in case it changed (though hash should be stable)
 
 
-    # Placeholder for where the processing logic will go
-    flag_file_path = FLAG_DIR / args.file_hash
-
-    processed_steps, base_name_from_flag = read_flag_file(flag_file_path)
-    log_message(f"Read from flag file: Steps={processed_steps}, BaseName='{base_name_from_flag}'")
-
-    # Example of how to record a step (actual recording will happen after each step)
-    current_base_name = base_name_from_flag
+    processed_steps = set(current_asset_data.get("processed_steps", []))
+    current_base_name = current_asset_data.get("base_name")
     full_description_content = ""
 
 
     # ---- Gemini Description Step ----
     if STEP_GEMINI_DESCRIPTION not in processed_steps:
         log_message(f"Running Gemini Description step for {args.input_file}...")
-        # Path to the get_gemini_description.py script, assuming it's in the same directory
         gemini_script_path = Path(__file__).parent / "get_gemini_description.py"
 
         cmd = [
@@ -94,14 +160,17 @@ def main():
                     # Use a generic base_name based on hash if Gemini fails to produce a valid one
                     current_base_name = f"generic-media-{args.file_hash[:8]}"
                     # The get_gemini_description.py script itself creates an error .md file.
-                    # We won't record base_name to flag on error, to allow retry of Gemini step.
+                    # We won't record base_name to index on error, to allow retry of Gemini step.
                 else:
                     log_message(f"Gemini script succeeded. Base name: {gemini_output_base_name}")
                     current_base_name = gemini_output_base_name
-                    record_step_in_flag_file(flag_file_path, STEP_GEMINI_DESCRIPTION)
-                    record_base_name_in_flag_file(flag_file_path, current_base_name)
+                    current_asset_data["base_name"] = current_base_name
+                    # The get_gemini_description.py script creates the .md file.
+                    # We construct the expected path to store it in the index.
+                    current_asset_data["description_markdown_path"] = str(DESCRIPTION_DIR / f"{current_base_name}.md")
                     processed_steps.add(STEP_GEMINI_DESCRIPTION)
-                    log_message(f"Recorded {STEP_GEMINI_DESCRIPTION} and base_name '{current_base_name}' to {flag_file_path}")
+                    current_asset_data["processed_steps"] = sorted(list(processed_steps))
+                    log_message(f"Updated asset data with base_name '{current_base_name}' and step {STEP_GEMINI_DESCRIPTION}")
             else:
                 log_message(f"Gemini script failed with return code {result.returncode}.", level="ERROR")
                 log_message(f"Stderr: {result.stderr.strip()}", level="ERROR")
@@ -117,28 +186,39 @@ def main():
 
     else:
         log_message(f"Skipping Gemini Description step for {args.input_file} (already processed).")
-        if not current_base_name:
-            log_message("Error: Gemini description was flagged as done, but base_name could not be retrieved from flag file. This indicates a potential issue with flag file integrity or initial population.", level="ERROR")
-            # Fallback, though this situation implies a problem.
+        if not current_base_name: # Should be current_asset_data["base_name"]
+            log_message("Error: Gemini description was marked as processed, but base_name is missing in index data.", level="ERROR")
+            # Fallback if base_name is somehow missing after being processed.
             current_base_name = f"generic-recovery-{args.file_hash[:8]}"
+            current_asset_data["base_name"] = current_base_name # Attempt to fix current_asset_data
 
-    # Load description content if base_name is available
-    if current_base_name:
-        description_md_file = DESCRIPTION_DIR / f"{current_base_name}.md"
+    # Load description content if base_name is available and description path is set
+    if current_base_name and current_asset_data.get("description_markdown_path"):
+        description_md_file = Path(current_asset_data["description_markdown_path"])
         if description_md_file.exists():
-            with open(description_md_file, "r", encoding="utf-8") as f_desc:
-                full_description_content = f_desc.read()
-            log_message(f"Loaded description from {description_md_file}")
+            try:
+                with open(description_md_file, "r", encoding="utf-8") as f_desc:
+                    full_description_content = f_desc.read()
+                log_message(f"Loaded description from {description_md_file}")
+            except IOError as e:
+                log_message(f"Error reading description file {description_md_file}: {e}", level="ERROR")
+                full_description_content = "Error reading description file."
         else:
             log_message(f"Warning: Description file {description_md_file} not found, even after Gemini step (or skip).", level="WARNING")
             full_description_content = "Description file was expected but not found."
-    else: # This case should ideally be handled by fallbacks above to always have some current_base_name
+    elif current_base_name and not current_asset_data.get("description_markdown_path"):
+        log_message(f"Warning: base_name '{current_base_name}' exists, but description_markdown_path is not set in index.", level="WARNING")
+        # Try to reconstruct path if needed, or handle as missing
+        # For now, treat as missing content.
+        full_description_content = "Description path missing in index."
+    elif not current_base_name:
         log_message("Critical Error: base_name is not set after Gemini step. Cannot proceed with further file-specific processing.", level="ERROR")
-        # Depending on desired strictness, could exit here: sys.exit(1)
-        # For now, we'll let it continue and subsequent steps might fail or use a very generic name if they don't also check current_base_name
+        # Update index before exiting due to critical error
+        index_data = update_asset_in_index(index_data, current_asset_data)
+        save_index_data(INDEX_FILE_PATH, index_data)
+        sys.exit(1) # Exit if no base_name, as it's crucial.
 
     log_message(f"Using base_name: '{current_base_name}' for outputs.")
-    # log_message(f"Using description: '{full_description_content[:100]}...'")
 
 
     # ---- Determine File Type ----
@@ -146,21 +226,34 @@ def main():
     is_image = file_extension in ['.jpg', '.jpeg', '.png', '.gif', '.webp']
     is_video = file_extension in ['.mp4', '.mov', '.avi', '.mkv', '.webm', '.flv']
 
-    if not current_base_name and (is_image or is_video):
+    # Set asset type in index
+    if is_image:
+        current_asset_data["outputs"]["type"] = "image"
+    elif is_video:
+        current_asset_data["outputs"]["type"] = "video"
+    else:
+        current_asset_data["outputs"]["type"] = "unknown"
+
+
+    if not current_base_name and (is_image or is_video): # This check is somewhat redundant due to earlier exit
         log_message("Critical: base_name is not set, but processing is required for image/video. Aborting this file.", level="ERROR")
-        # In a real scenario, might want to sys.exit(1) or raise an exception
-        # For now, we'll just skip further processing for this file.
+        index_data = update_asset_in_index(index_data, current_asset_data)
+        save_index_data(INDEX_FILE_PATH, index_data)
+        sys.exit(1)
+
     elif is_image:
         # ---- Image Conversion Step ----
         if STEP_IMAGE_CONVERSION not in processed_steps:
             log_message(f"Running Image Conversion step for {args.input_file}...")
             widths = [1920, 1280, 640]
             conversion_ok = True
+            current_asset_data["outputs"]["image_files"] = [] # Clear previous attempts if any
+
             for width in widths:
                 try:
                     # JPEG
-                    output_jpg_rel_path = f"images/{current_base_name}-{width}w.jpg"
-                    output_jpg_abs_path = IMAGE_DIR / f"{current_base_name}-{width}w.jpg"
+                    jpg_filename = f"{current_base_name}-{width}w.jpg"
+                    output_jpg_abs_path = IMAGE_DIR / jpg_filename
                     cmd_convert_jpg = [
                         "convert", args.input_file, "-resize", f"{width}x>", "-quality", "85", str(output_jpg_abs_path)
                     ]
@@ -168,13 +261,16 @@ def main():
                     cmd_exif_jpg = [
                         "exiftool", "-tagsFromFile", args.input_file, "-all:all", "-overwrite_original", str(output_jpg_abs_path)
                     ]
-                    subprocess.run(cmd_exif_jpg, check=False, capture_output=True) # check=False as exiftool can have non-fatal warnings
+                    subprocess.run(cmd_exif_jpg, check=False, capture_output=True)
                     if (output_jpg_abs_path.parent / f"{output_jpg_abs_path.name}_original").exists():
                         (output_jpg_abs_path.parent / f"{output_jpg_abs_path.name}_original").unlink()
+                    current_asset_data["outputs"]["image_files"].append({
+                        "format": "jpg", "width": width, "path": str(IMAGE_DIR.name / jpg_filename) # Store relative path
+                    })
 
                     # WebP
-                    output_webp_rel_path = f"images/{current_base_name}-{width}w.webp"
-                    output_webp_abs_path = IMAGE_DIR / f"{current_base_name}-{width}w.webp"
+                    webp_filename = f"{current_base_name}-{width}w.webp"
+                    output_webp_abs_path = IMAGE_DIR / webp_filename
                     cmd_convert_webp = [
                         "convert", args.input_file, "-resize", f"{width}x>", "-quality", "80", str(output_webp_abs_path)
                     ]
@@ -185,63 +281,101 @@ def main():
                     subprocess.run(cmd_exif_webp, check=False, capture_output=True)
                     if (output_webp_abs_path.parent / f"{output_webp_abs_path.name}_original").exists():
                         (output_webp_abs_path.parent / f"{output_webp_abs_path.name}_original").unlink()
-
+                    current_asset_data["outputs"]["image_files"].append({
+                        "format": "webp", "width": width, "path": str(IMAGE_DIR.name / webp_filename) # Store relative path
+                    })
                     log_message(f"Successfully converted to {width}w (JPG/WebP) for {current_base_name}")
 
                 except subprocess.CalledProcessError as e:
                     log_message(f"Error during image conversion for width {width}: {e.stderr.decode() if e.stderr else e.stdout.decode()}", level="ERROR")
                     conversion_ok = False
-                    break # Stop processing further widths for this image
+                    break
                 except Exception as e_gen:
                     log_message(f"Generic error during image conversion for width {width}: {e_gen}", level="ERROR")
                     conversion_ok = False
                     break
 
             if conversion_ok:
-                record_step_in_flag_file(flag_file_path, STEP_IMAGE_CONVERSION)
                 processed_steps.add(STEP_IMAGE_CONVERSION)
-                log_message(f"Image conversion successful. Recorded {STEP_IMAGE_CONVERSION} to {flag_file_path}")
+                current_asset_data["processed_steps"] = sorted(list(processed_steps))
+                log_message(f"Image conversion successful. Updated asset data with step {STEP_IMAGE_CONVERSION}")
             else:
-                log_message("Image conversion failed. Not flagging as complete.", level="ERROR")
+                log_message("Image conversion failed. Not marking step as complete.", level="ERROR")
         else:
             log_message(f"Skipping Image Conversion for {args.input_file} (already processed).")
 
         # ---- HTML Generation Step ----
-        # Check if image conversion is done (either just now or previously) or if files physically exist (as a fallback)
-        # A simple check for one of the expected output files from image conversion:
-        expected_image_file_check = IMAGE_DIR / f"{current_base_name}-640w.jpg"
+        expected_image_file_check = IMAGE_DIR / f"{current_base_name}-640w.jpg" # Check for one expected file
         if (STEP_IMAGE_CONVERSION in processed_steps or expected_image_file_check.exists()):
             if STEP_HTML_GENERATION not in processed_steps:
                 log_message(f"Running HTML Generation for {args.input_file}...")
+                # Use raw_content_url_prefix from current_asset_data
+                raw_content_url_prefix = current_asset_data["raw_content_url_prefix"]
+                html_filename = f"{current_base_name}.html"
+                output_html_file_abs = HTML_DIR / html_filename # Absolute path for writing
+                output_html_file_rel = str(HTML_DIR.name / html_filename) # Relative path for index
 
-                raw_content_url_prefix = f"https://raw.githubusercontent.com/{args.github_repository}/{args.github_ref_for_raw_url}/"
-                output_html_file = HTML_DIR / f"{current_base_name}.html"
-
-                widths = [1920, 1280, 640] # Ensure widths is available
+                widths = [1920, 1280, 640]
                 webp_srcset_parts = []
                 jpeg_srcset_parts = []
 
-                for width_val in widths:
-                    webp_src = f"{raw_content_url_prefix}processed_media/images/{current_base_name}-{width_val}w.webp"
-                    jpeg_src = f"{raw_content_url_prefix}processed_media/images/{current_base_name}-{width_val}w.jpg"
-                    webp_srcset_parts.append(f"{webp_src} {width_val}w")
-                    jpeg_srcset_parts.append(f"{jpeg_src} {width_val}w")
+                # Construct srcset using relative paths from index and raw_content_url_prefix
+                # This assumes image_files in index are correctly populated with relative paths
+                for img_output in current_asset_data["outputs"].get("image_files", []):
+                    # img_output["path"] should be like "images/basename-1280w.jpg"
+                    # So, raw_content_url_prefix + "processed_media/" + img_output["path"]
+                    # No, BASE_OUTPUT_DIR.name is "processed_media"
+                    # So, raw_content_url_prefix + BASE_OUTPUT_DIR.name + "/" + img_output["path"]
+                    # Correct: raw_content_url_prefix + img_output["path"] if path includes "processed_media/images/..."
+                    # The stored path is currently "images/basename-1280w.jpg".
+                    # So it should be raw_content_url_prefix + "processed_media/" + img_output["path"]
+
+                    # The path stored in image_files is relative to BASE_OUTPUT_DIR ("processed_media")
+                    # e.g. images/my-image-1280w.jpg
+                    # So the full URL should be raw_content_url_prefix + "processed_media/" + stored_path
+
+                    # Let's re-evaluate how paths are stored in `image_files`.
+                    # Plan says: "Path to the generated image file."
+                    # For consistency, let's make it relative to repo root: "processed_media/images/..."
+                    # The current code stores it relative to IMAGE_DIR.name: "images/..."
+                    # This needs to be fixed when populating `image_files`.
+                    # For now, let's assume the paths in current_asset_data["outputs"]["image_files"]
+                    # are paths relative to `processed_media/` directory.
+                    # Example: if img_output["path"] is "images/crane-statue-garden-flowers-building-1280w.webp"
+                    # then full URL is raw_content_url_prefix + "processed_media/" + img_output["path"]
+
+                    # The current code for populating image_files:
+                    # str(IMAGE_DIR.name / jpg_filename) -> "images/base-1280w.jpg"
+                    # This is relative to `processed_media`.
+                    # So, the URL construction should be:
+                    # image_url = f"{raw_content_url_prefix}{BASE_OUTPUT_DIR.name}/{img_output['path']}"
+
+                    image_url = f"{raw_content_url_prefix}{BASE_OUTPUT_DIR.name}/{img_output['path']}"
+
+                    if img_output["format"] == "webp":
+                        webp_srcset_parts.append(f"{image_url} {img_output['width']}w")
+                    elif img_output["format"] == "jpg":
+                        jpeg_srcset_parts.append(f"{image_url} {img_output['width']}w")
 
                 webp_srcset = ", ".join(webp_srcset_parts)
                 jpeg_srcset = ", ".join(jpeg_srcset_parts)
 
-                fallback_img_src = f"{raw_content_url_prefix}processed_media/images/{current_base_name}-640w.jpg"
+                # Fallback image: find the 640w JPG
+                fallback_img_src = ""
+                for img_output in current_asset_data["outputs"].get("image_files", []):
+                    if img_output["format"] == "jpg" and img_output["width"] == 640:
+                        fallback_img_src = f"{raw_content_url_prefix}{BASE_OUTPUT_DIR.name}/{img_output['path']}"
+                        break
+                if not fallback_img_src and jpeg_srcset_parts: # Fallback to any jpg if 640 not found
+                     fallback_img_src = jpeg_srcset_parts[0].split(" ")[0]
 
-                # Escape alt text for HTML attributes using html.escape()
+
                 escaped_alt_text = html.escape(full_description_content)
-
-                # Read HTML template
                 template_path = Path(__file__).parent / "templates" / "media_template.html"
                 try:
                     with open(template_path, "r", encoding="utf-8") as f_template:
                         html_template_content = f_template.read()
 
-                    # Populate template
                     html_content = html_template_content.replace("{{TITLE}}", current_base_name)
                     html_content = html_content.replace("{{BASE_NAME}}", current_base_name)
                     html_content = html_content.replace("{{WEBP_SRCSET}}", webp_srcset)
@@ -249,18 +383,19 @@ def main():
                     html_content = html_content.replace("{{FALLBACK_IMG_SRC}}", fallback_img_src)
                     html_content = html_content.replace("{{ALT_TEXT}}", escaped_alt_text)
 
-                    with open(output_html_file, "w", encoding="utf-8") as f_html:
+                    with open(output_html_file_abs, "w", encoding="utf-8") as f_html:
                         f_html.write(html_content)
-                    log_message(f"Generated HTML file: {output_html_file} from template (using raw GitHub URLs)")
-                    record_step_in_flag_file(flag_file_path, STEP_HTML_GENERATION)
-                    processed_steps.add(STEP_HTML_GENERATION) # Update local set for current run
+                    log_message(f"Generated HTML file: {output_html_file_abs}")
+                    current_asset_data["outputs"]["html_page_path"] = str(BASE_OUTPUT_DIR.name / HTML_DIR.name / html_filename) # Store relative to repo root
+                    processed_steps.add(STEP_HTML_GENERATION)
+                    current_asset_data["processed_steps"] = sorted(list(processed_steps))
                 except FileNotFoundError:
                     log_message(f"Error: HTML template file not found at {template_path}", level="ERROR")
                 except IOError as e:
-                    log_message(f"Error reading HTML template or writing HTML file {output_html_file}: {e}", level="ERROR")
-            else: # Corresponds to: if STEP_HTML_GENERATION not in processed_steps
+                    log_message(f"Error reading HTML template or writing HTML file {output_html_file_abs}: {e}", level="ERROR")
+            else:
                 log_message(f"Skipping HTML Generation for {args.input_file} (already processed).")
-        else: # Corresponds to: if (STEP_IMAGE_CONVERSION in processed_steps or expected_image_file_check.exists())
+        else:
             log_message(f"Skipping HTML Generation for {args.input_file} because image conversion step is not flagged as complete or expected image files are missing.")
 
     elif is_video:
@@ -268,43 +403,52 @@ def main():
             log_message(f"Running Video Conversion step for {args.input_file}...")
             heights = [1080, 720]
             conversion_ok = True
+            current_asset_data["outputs"]["video_files"] = [] # Clear previous attempts
+
             for height in heights:
                 try:
                     # MP4 (H.264)
-                    output_mp4_path = VIDEO_DIR / f"{current_base_name}-{height}p.mp4"
+                    mp4_filename = f"{current_base_name}-{height}p.mp4"
+                    output_mp4_abs_path = VIDEO_DIR / mp4_filename
                     cmd_ffmpeg_mp4 = [
                         "ffmpeg", "-i", args.input_file,
-                        "-vf", f"scale=-2:min(ih\\,{height})", # Note: Escaping comma for shell, not strictly needed for list arg in Python unless it was one string
+                        "-vf", f"scale=-2:min(ih\\,{height})",
                         "-c:v", "libx264", "-preset", "medium", "-crf", "23",
                         "-c:a", "aac", "-b:a", "128k",
                         "-movflags", "+faststart",
-                        str(output_mp4_path), "-y"
+                        str(output_mp4_abs_path), "-y"
                     ]
                     subprocess.run(cmd_ffmpeg_mp4, check=True, capture_output=True)
                     cmd_exif_mp4 = [
-                        "exiftool", "-tagsFromFile", args.input_file, "-all:all", "-overwrite_original", str(output_mp4_path)
+                        "exiftool", "-tagsFromFile", args.input_file, "-all:all", "-overwrite_original", str(output_mp4_abs_path)
                     ]
                     subprocess.run(cmd_exif_mp4, check=False, capture_output=True)
-                    if (output_mp4_path.parent / f"{output_mp4_path.name}_original").exists():
-                        (output_mp4_path.parent / f"{output_mp4_path.name}_original").unlink()
+                    if (output_mp4_abs_path.parent / f"{output_mp4_abs_path.name}_original").exists():
+                        (output_mp4_abs_path.parent / f"{output_mp4_abs_path.name}_original").unlink()
+                    current_asset_data["outputs"]["video_files"].append({
+                        "format": "mp4", "height": height, "path": str(BASE_OUTPUT_DIR.name / VIDEO_DIR.name / mp4_filename) # Relative to repo root
+                    })
 
                     # WebM (VP9)
-                    output_webm_path = VIDEO_DIR / f"{current_base_name}-{height}p.webm"
+                    webm_filename = f"{current_base_name}-{height}p.webm"
+                    output_webm_abs_path = VIDEO_DIR / webm_filename
                     cmd_ffmpeg_webm = [
                         "ffmpeg", "-i", args.input_file,
                         "-vf", f"scale=-2:min(ih\\,{height})",
                         "-c:v", "libvpx-vp9", "-crf", "30", "-b:v", "0",
                         "-c:a", "libopus", "-b:a", "128k",
-                        str(output_webm_path), "-y"
+                        str(output_webm_abs_path), "-y"
                     ]
                     subprocess.run(cmd_ffmpeg_webm, check=True, capture_output=True)
                     cmd_exif_webm = [
-                        "exiftool", "-tagsFromFile", args.input_file, "-all:all", "-overwrite_original", str(output_webm_path)
+                        "exiftool", "-tagsFromFile", args.input_file, "-all:all", "-overwrite_original", str(output_webm_abs_path)
                     ]
                     subprocess.run(cmd_exif_webm, check=False, capture_output=True)
-                    if (output_webm_path.parent / f"{output_webm_path.name}_original").exists():
-                        (output_webm_path.parent / f"{output_webm_path.name}_original").unlink()
-
+                    if (output_webm_abs_path.parent / f"{output_webm_abs_path.name}_original").exists():
+                        (output_webm_abs_path.parent / f"{output_webm_abs_path.name}_original").unlink()
+                    current_asset_data["outputs"]["video_files"].append({
+                        "format": "webm", "height": height, "path": str(BASE_OUTPUT_DIR.name / VIDEO_DIR.name / webm_filename) # Relative to repo root
+                    })
                     log_message(f"Successfully converted video to {height}p (MP4/WebM) for {current_base_name}")
 
                 except subprocess.CalledProcessError as e:
@@ -317,82 +461,24 @@ def main():
                     break
 
             if conversion_ok:
-                record_step_in_flag_file(flag_file_path, STEP_VIDEO_CONVERSION)
                 processed_steps.add(STEP_VIDEO_CONVERSION)
-                log_message(f"Video conversion successful. Recorded {STEP_VIDEO_CONVERSION} to {flag_file_path}")
+                current_asset_data["processed_steps"] = sorted(list(processed_steps))
+                log_message(f"Video conversion successful. Updated asset data with step {STEP_VIDEO_CONVERSION}")
             else:
-                log_message("Video conversion failed. Not flagging as complete.", level="ERROR")
+                log_message("Video conversion failed. Not marking step as complete.", level="ERROR")
         else:
             log_message(f"Skipping Video Conversion for {args.input_file} (already processed).")
     else:
         log_message(f"File {args.input_file} is not a recognized image or video type for media processing. Extension: {file_extension}")
 
+    # Save updated index data for this asset
+    index_data = update_asset_in_index(index_data, current_asset_data)
+    save_index_data(INDEX_FILE_PATH, index_data)
 
     log_message(f"Finished processing for file: {args.input_file}")
 
-def read_flag_file(flag_path: Path) -> tuple[set[str], str | None]:
-    """Reads the flag file and returns a set of processed steps and the base_name if found."""
-    processed_steps = set()
-    base_name = None
-    if flag_path.exists():
-        log_message(f"Reading flag file: {flag_path}")
-        with open(flag_path, "r", encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if line.startswith(BASE_NAME_FLAG_PREFIX):
-                    base_name = line.replace(BASE_NAME_FLAG_PREFIX, "", 1)
-                elif line: # Non-empty line
-                    processed_steps.add(line)
-    return processed_steps, base_name
-
-def record_step_in_flag_file(flag_path: Path, step_keyword: str):
-    """Appends a step keyword to the flag file if not already present."""
-    if flag_path.exists():
-        with open(flag_path, "r+", encoding="utf-8") as f:
-            existing_steps = {line.strip() for line in f}
-            if step_keyword not in existing_steps:
-                f.seek(0, os.SEEK_END) # Go to the end of file
-                if f.tell() > 0: # If file is not empty, add a newline
-                     # Check if the last char is a newline
-                    f.seek(f.tell() -1, os.SEEK_SET)
-                    if f.read(1) != '\n':
-                        f.write('\n')
-                f.write(f"{step_keyword}\n")
-                log_message(f"Recorded step '{step_keyword}' to {flag_path}")
-            else:
-                log_message(f"Step '{step_keyword}' already in {flag_path}")
-    else: # File does not exist, create it and write the step
-        with open(flag_path, "w", encoding="utf-8") as f:
-            f.write(f"{step_keyword}\n")
-        log_message(f"Created flag file {flag_path} and recorded step '{step_keyword}'")
-
-def record_base_name_in_flag_file(flag_path: Path, base_name: str):
-    """Adds or updates the base_name line in the flag file."""
-    base_name_line = f"{BASE_NAME_FLAG_PREFIX}{base_name}"
-    lines = []
-    found_base_name = False
-    if flag_path.exists():
-        with open(flag_path, "r", encoding="utf-8") as f:
-            lines = f.readlines()
-
-        with open(flag_path, "w", encoding="utf-8") as f:
-            for line in lines:
-                if line.strip().startswith(BASE_NAME_FLAG_PREFIX):
-                    f.write(f"{base_name_line}\n")
-                    found_base_name = True
-                else:
-                    f.write(line)
-            if not found_base_name:
-                # Ensure there's a newline if adding to an existing file with other content
-                if lines and not lines[-1].endswith('\n'):
-                    f.write('\n')
-                f.write(f"{base_name_line}\n")
-        log_message(f"Recorded base_name '{base_name}' to {flag_path}")
-    else: # File does not exist, create it
-        with open(flag_path, "w", encoding="utf-8") as f:
-            f.write(f"{base_name_line}\n")
-        log_message(f"Created flag file {flag_path} and recorded base_name '{base_name}'")
-
+# Removed old flag file functions:
+# read_flag_file, record_step_in_flag_file, record_base_name_in_flag_file
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/process_file.py
+++ b/.github/scripts/process_file.py
@@ -265,7 +265,7 @@ def main():
                     if (output_jpg_abs_path.parent / f"{output_jpg_abs_path.name}_original").exists():
                         (output_jpg_abs_path.parent / f"{output_jpg_abs_path.name}_original").unlink()
                     current_asset_data["outputs"]["image_files"].append({
-                        "format": "jpg", "width": width, "path": str(IMAGE_DIR.name / jpg_filename) # Store relative path
+                        "format": "jpg", "width": width, "path": str(Path(IMAGE_DIR.name) / jpg_filename) # Store path relative to BASE_OUTPUT_DIR
                     })
 
                     # WebP
@@ -282,7 +282,7 @@ def main():
                     if (output_webp_abs_path.parent / f"{output_webp_abs_path.name}_original").exists():
                         (output_webp_abs_path.parent / f"{output_webp_abs_path.name}_original").unlink()
                     current_asset_data["outputs"]["image_files"].append({
-                        "format": "webp", "width": width, "path": str(IMAGE_DIR.name / webp_filename) # Store relative path
+                        "format": "webp", "width": width, "path": str(Path(IMAGE_DIR.name) / webp_filename) # Store path relative to BASE_OUTPUT_DIR
                     })
                     log_message(f"Successfully converted to {width}w (JPG/WebP) for {current_base_name}")
 
@@ -313,7 +313,7 @@ def main():
                 raw_content_url_prefix = current_asset_data["raw_content_url_prefix"]
                 html_filename = f"{current_base_name}.html"
                 output_html_file_abs = HTML_DIR / html_filename # Absolute path for writing
-                output_html_file_rel = str(HTML_DIR.name / html_filename) # Relative path for index
+                # output_html_file_rel = str(HTML_DIR.name / html_filename) # This line caused a TypeError and was unused. Removing.
 
                 widths = [1920, 1280, 640]
                 webp_srcset_parts = []

--- a/.github/scripts/process_file.py
+++ b/.github/scripts/process_file.py
@@ -426,7 +426,7 @@ def main():
                     if (output_mp4_abs_path.parent / f"{output_mp4_abs_path.name}_original").exists():
                         (output_mp4_abs_path.parent / f"{output_mp4_abs_path.name}_original").unlink()
                     current_asset_data["outputs"]["video_files"].append({
-                        "format": "mp4", "height": height, "path": str(BASE_OUTPUT_DIR.name / VIDEO_DIR.name / mp4_filename) # Relative to repo root
+                        "format": "mp4", "height": height, "path": str(Path(VIDEO_DIR.name) / mp4_filename) # Relative to BASE_OUTPUT_DIR
                     })
 
                     # WebM (VP9)
@@ -447,7 +447,7 @@ def main():
                     if (output_webm_abs_path.parent / f"{output_webm_abs_path.name}_original").exists():
                         (output_webm_abs_path.parent / f"{output_webm_abs_path.name}_original").unlink()
                     current_asset_data["outputs"]["video_files"].append({
-                        "format": "webm", "height": height, "path": str(BASE_OUTPUT_DIR.name / VIDEO_DIR.name / webm_filename) # Relative to repo root
+                        "format": "webm", "height": height, "path": str(Path(VIDEO_DIR.name) / webm_filename) # Relative to BASE_OUTPUT_DIR
                     })
                     log_message(f"Successfully converted video to {height}p (MP4/WebM) for {current_base_name}")
 

--- a/.github/scripts/process_file.py
+++ b/.github/scripts/process_file.py
@@ -386,7 +386,7 @@ def main():
                     with open(output_html_file_abs, "w", encoding="utf-8") as f_html:
                         f_html.write(html_content)
                     log_message(f"Generated HTML file: {output_html_file_abs}")
-                    current_asset_data["outputs"]["html_page_path"] = str(BASE_OUTPUT_DIR.name / HTML_DIR.name / html_filename) # Store relative to repo root
+                    current_asset_data["outputs"]["html_page_path"] = str(Path(BASE_OUTPUT_DIR.name) / HTML_DIR.name / html_filename) # Store relative to repo root
                     processed_steps.add(STEP_HTML_GENERATION)
                     current_asset_data["processed_steps"] = sorted(list(processed_steps))
                 except FileNotFoundError:

--- a/.github/workflows/process_media.yml
+++ b/.github/workflows/process_media.yml
@@ -109,33 +109,25 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
           echo "Staging processed files for commit..."
-          # Function to add files from a directory if it exists and is not empty
-          add_files_if_present() {
-            local dir_path="$1"
-            local pattern="$2"
-            if [ -d "$dir_path" ] && [ -n "$(ls -A "$dir_path")" ]; then
-              echo "Adding files from $dir_path with pattern $pattern"
-              git add "$dir_path/$pattern"
-            else
-              echo "No files to add from $dir_path or directory does not exist."
-            fi
-          }
+          # Stage all new, modified, and deleted files within processed_media/ and for index.json
+          git add -A processed_media/ index.json || echo "Warning: git add command encountered an issue or no files to add from processed_media or index.json."
 
-          add_files_if_present "processed_media/images" "*"
-          add_files_if_present "processed_media/videos" "*"
-          add_files_if_present "processed_media/descriptions" "*.md"
-          add_files_if_present "processed_media/html" "*.html"
-          # add_files_if_present "processed_flags" "*" # No longer needed
-
-          # Add index.json if it exists and has changes
-          if [ -f "index.json" ]; then
-            git add index.json
-          fi
+          echo "Current git status before commit:"
+          git status -s
 
           # Only commit if there are changes staged
           if ! git diff --staged --quiet; then
+            echo "Files staged for commit:"
+            git diff --staged --name-only
+
+            echo "Files staged for commit:"
+            git diff --staged --name-only
+
             echo "Committing changes..."
             git commit -m "Process media files, add descriptions, and preserve metadata"
+
+            echo "Git status after commit (before fetch/rebase):"
+            git status -s
 
             CURRENT_BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
 

--- a/.github/workflows/process_media.yml
+++ b/.github/workflows/process_media.yml
@@ -137,15 +137,17 @@ jobs:
             echo "Committing changes..."
             git commit -m "Process media files, add descriptions, and preserve metadata"
 
-            TARGET_BRANCH="${{ github.head_ref || github.ref_name }}"
-            # Attempt to pull and rebase before pushing to avoid (fetch first) errors
-            echo "Pulling latest changes with rebase from origin $TARGET_BRANCH..."
-            # Allow the pull to fail if the branch doesn't exist remotely yet (e.g. first push to a new PR branch by the action)
-            # Or if there are complex conflicts, though bot changes should be fairly isolated.
-            git pull origin "$TARGET_BRANCH" --rebase || echo "Pull/rebase failed, proceeding with push attempt."
+            CURRENT_BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
 
-            echo "Pushing changes to origin HEAD:$TARGET_BRANCH"
-            git push origin HEAD:"$TARGET_BRANCH"
+            echo "Fetching origin..."
+            git fetch origin
+
+            echo "Rebasing local commit onto origin/$CURRENT_BRANCH_NAME..."
+            # If rebase fails (e.g. conflicts), the workflow will stop here.
+            git rebase "origin/$CURRENT_BRANCH_NAME"
+
+            echo "Pushing changes to origin HEAD:$CURRENT_BRANCH_NAME"
+            git push origin HEAD:"$CURRENT_BRANCH_NAME"
           else
             echo "No changes to commit."
           fi

--- a/.github/workflows/process_media.yml
+++ b/.github/workflows/process_media.yml
@@ -136,9 +136,14 @@ jobs:
           if ! git diff --staged --quiet; then
             echo "Committing changes..."
             git commit -m "Process media files, add descriptions, and preserve metadata"
-            # Push to the current branch, whether it's a PR branch or a direct push
-            # GITHUB_HEAD_REF is the source branch in a PR, GITHUB_REF_NAME is the branch/tag name for push events
+
             TARGET_BRANCH="${{ github.head_ref || github.ref_name }}"
+            # Attempt to pull and rebase before pushing to avoid (fetch first) errors
+            echo "Pulling latest changes with rebase from origin $TARGET_BRANCH..."
+            # Allow the pull to fail if the branch doesn't exist remotely yet (e.g. first push to a new PR branch by the action)
+            # Or if there are complex conflicts, though bot changes should be fairly isolated.
+            git pull origin "$TARGET_BRANCH" --rebase || echo "Pull/rebase failed, proceeding with push attempt."
+
             echo "Pushing changes to origin HEAD:$TARGET_BRANCH"
             git push origin HEAD:"$TARGET_BRANCH"
           else

--- a/.github/workflows/process_media.yml
+++ b/.github/workflows/process_media.yml
@@ -136,7 +136,11 @@ jobs:
           if ! git diff --staged --quiet; then
             echo "Committing changes..."
             git commit -m "Process media files, add descriptions, and preserve metadata"
-            git push
+            # Push to the current branch, whether it's a PR branch or a direct push
+            # GITHUB_HEAD_REF is the source branch in a PR, GITHUB_REF_NAME is the branch/tag name for push events
+            TARGET_BRANCH="${{ github.head_ref || github.ref_name }}"
+            echo "Pushing changes to origin HEAD:$TARGET_BRANCH"
+            git push origin HEAD:"$TARGET_BRANCH"
           else
             echo "No changes to commit."
           fi

--- a/.github/workflows/process_media.yml
+++ b/.github/workflows/process_media.yml
@@ -39,7 +39,7 @@ jobs:
           mkdir -p processed_media/videos
           mkdir -p processed_media/descriptions # For .md files
           mkdir -p processed_media/html # For .html files
-          mkdir -p processed_flags
+          # mkdir -p processed_flags # No longer needed
 
       - name: Process new media files
         id: process_files
@@ -116,7 +116,12 @@ jobs:
           add_files_if_present "processed_media/videos" "*"
           add_files_if_present "processed_media/descriptions" "*.md"
           add_files_if_present "processed_media/html" "*.html"
-          add_files_if_present "processed_flags" "*"
+          # add_files_if_present "processed_flags" "*" # No longer needed
+
+          # Add index.json if it exists and has changes
+          if [ -f "index.json" ]; then
+            git add index.json
+          fi
 
           # Only commit if there are changes staged
           if ! git diff --staged --quiet; then

--- a/.github/workflows/process_media.yml
+++ b/.github/workflows/process_media.yml
@@ -9,7 +9,16 @@ on:
     paths:
       - 'uploads/**'
       - '.github/workflows/process_media.yml'
-      - '.github/scripts/get_gemini_description.py'
+      - '.github/scripts/**' # Monitor all scripts
+
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - 'main' # Or your default branch
+    paths:
+      - 'uploads/**'
+      - '.github/workflows/process_media.yml'
+      - '.github/scripts/**'
 
 permissions:
   contents: write

--- a/index.html
+++ b/index.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Processed Media Catalog</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <style>
+        body { font-family: sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
+        header { text-align: center; margin-bottom: 30px; }
+        #catalog { display: grid; grid-template-columns: repeat(auto-fill, minmax(350px, 1fr)); gap: 20px; }
+        .asset { background-color: #fff; border: 1px solid #ddd; border-radius: 8px; padding: 15px; box-shadow: 0 2px 5px rgba(0,0,0,0.1); }
+        .asset h2 { margin-top: 0; font-size: 1.5em; color: #0056b3; }
+        .asset img, .asset video { max-width: 100%; height: auto; border-radius: 4px; margin-bottom: 10px; }
+        .asset .description { margin-bottom: 15px; padding: 10px; border: 1px solid #eee; border-radius: 4px; background-color: #f9f9f9; }
+        .asset .description p:last-child { margin-bottom: 0; }
+        .asset-details { font-size: 0.9em; color: #555; }
+        .asset-details strong { color: #333; }
+        .asset-details ul { padding-left: 20px; margin-top: 5px; }
+        .asset-details a { color: #007bff; text-decoration: none; }
+        .asset-details a:hover { text-decoration: underline; }
+        .loader { text-align: center; font-size: 1.2em; padding: 20px; }
+        .error-message { color: red; text-align: center; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Processed Media Catalog</h1>
+    </header>
+    <div id="catalog">
+        <div class="loader">Loading assets...</div>
+    </div>
+
+    <script>
+        async function fetchIndexAndDisplay() {
+            const catalogDiv = document.getElementById('catalog');
+            try {
+                const response = await fetch('index.json?t=' + new Date().getTime()); // Cache buster
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                const assets = await response.json();
+
+                catalogDiv.innerHTML = ''; // Clear loader
+
+                if (!assets || assets.length === 0) {
+                    catalogDiv.innerHTML = '<p>No assets found in index.json.</p>';
+                    return;
+                }
+
+                assets.forEach(asset => {
+                    const assetDiv = document.createElement('div');
+                    assetDiv.className = 'asset';
+
+                    let mediaHTML = '';
+                    const rawPrefix = asset.raw_content_url_prefix || ''; // Use stored prefix
+                    const processedMediaBase = rawPrefix + 'processed_media/';
+
+
+                    if (asset.outputs.type === 'image') {
+                        const webpSources = asset.outputs.image_files
+                            .filter(f => f.format === 'webp')
+                            .map(f => `${processedMediaBase}${f.path} ${f.width}w`)
+                            .join(', ');
+                        const jpgSources = asset.outputs.image_files
+                            .filter(f => f.format === 'jpg')
+                            .map(f => `${processedMediaBase}${f.path} ${f.width}w`)
+                            .join(', ');
+
+                        let fallbackSrc = '';
+                        const fallbackJpg = asset.outputs.image_files.find(f => f.format === 'jpg' && f.width === 640);
+                        if (fallbackJpg) {
+                            fallbackSrc = `${processedMediaBase}${fallbackJpg.path}`;
+                        } else {
+                            // If 640w JPG is not found, use the smallest JPG available as fallback
+                            const smallestJpg = asset.outputs.image_files
+                                .filter(f => f.format === 'jpg')
+                                .sort((a, b) => a.width - b.width)[0];
+                            if (smallestJpg) {
+                                fallbackSrc = `${processedMediaBase}${smallestJpg.path}`;
+                            }
+                        }
+
+                        mediaHTML = `
+                            <picture>
+                                ${webpSources ? `<source srcset="${webpSources}" type="image/webp">` : ''}
+                                ${jpgSources ? `<source srcset="${jpgSources}" type="image/jpeg">` : ''}
+                                ${fallbackSrc ? `<img src="${fallbackSrc}" alt="${asset.base_name || 'Processed Image'}">` : '<p>Image not available</p>'}
+                            </picture>
+                        `;
+                    } else if (asset.outputs.type === 'video') {
+                        const mp4Source = asset.outputs.video_files.find(f => f.format === 'mp4');
+                        const webmSource = asset.outputs.video_files.find(f => f.format === 'webm');
+                        mediaHTML = `
+                            <video controls preload="metadata" style="width:100%;">
+                                ${webmSource ? `<source src="${processedMediaBase}${webmSource.path}" type="video/webm">` : ''}
+                                ${mp4Source ? `<source src="${processedMediaBase}${mp4Source.path}" type="video/mp4">` : ''}
+                                Your browser does not support the video tag.
+                            </video>
+                        `;
+                    }
+
+                    let descriptionRenderedHtml = '<p>No description available.</p>';
+                    if (asset.description_markdown_path) {
+                        // Fetch markdown content - this is a simplified approach
+                        // In a real app, you might pre-fetch or handle errors more gracefully
+                        fetch(`${rawPrefix}${asset.description_markdown_path}?t=${new Date().getTime()}`)
+                            .then(res => res.text())
+                            .then(md => {
+                                if (md && !md.startsWith("<!DOCTYPE html>")) { // Basic check if content is markdown
+                                   assetDiv.querySelector('.description').innerHTML = marked.parse(md);
+                                } else {
+                                   assetDiv.querySelector('.description').innerHTML = '<p>Could not load description.</p>';
+                                }
+                            })
+                            .catch(err => {
+                                console.error('Error fetching markdown:', err);
+                                assetDiv.querySelector('.description').innerHTML = '<p>Error loading description.</p>';
+                            });
+                        descriptionRenderedHtml = '<div class="description-loading">Loading description...</div>'; // Placeholder
+                    }
+
+
+                    assetDiv.innerHTML = `
+                        <h2>${asset.base_name || 'Untitled Asset'}</h2>
+                        ${mediaHTML}
+                        <div class="description">
+                            ${descriptionRenderedHtml}
+                        </div>
+                        <div class="asset-details">
+                            <p><strong>Source File:</strong> ${asset.source_file_path}</p>
+                            <p><strong>Source Hash:</strong> ${asset.source_hash}</p>
+                            ${asset.outputs.html_page_path ? `<p><strong>HTML Page:</strong> <a href="${rawPrefix}${asset.outputs.html_page_path}" target="_blank">${asset.outputs.html_page_path.replace('processed_media/', '')}</a></p>` : ''}
+                            <p><strong>Processed Steps:</strong></p>
+                            <ul>
+                                ${asset.processed_steps && asset.processed_steps.length > 0 ? asset.processed_steps.map(step => `<li>${step}</li>`).join('') : '<li>None</li>'}
+                            </ul>
+                        </div>
+                    `;
+                    catalogDiv.appendChild(assetDiv);
+
+                    // Fetch and render markdown if path exists (if not done inline already)
+                    if (asset.description_markdown_path && assetDiv.querySelector('.description-loading')) {
+                         fetch(`${rawPrefix}${asset.description_markdown_path}?t=${new Date().getTime()}`)
+                            .then(response => {
+                                if (!response.ok) throw new Error(`Failed to fetch markdown: ${response.statusText}`);
+                                return response.text();
+                            })
+                            .then(md => {
+                                const descDiv = assetDiv.querySelector('.description');
+                                if (descDiv) { // Check if div still exists
+                                    if (md && (md.trim() !== "") && !md.toLowerCase().includes("<!doctype html>")) {
+                                        descDiv.innerHTML = marked.parse(md);
+                                    } else if (md.trim() === "") {
+                                        descDiv.innerHTML = "<p>Description is empty.</p>";
+                                    } else {
+                                        descDiv.innerHTML = "<p>Could not load or parse description (unexpected content).</p>";
+                                    }
+                                }
+                            })
+                            .catch(err => {
+                                console.error('Error fetching or parsing markdown:', asset.description_markdown_path, err);
+                                const descDiv = assetDiv.querySelector('.description');
+                                if (descDiv) {
+                                   descDiv.innerHTML = '<p>Error loading description.</p>';
+                                }
+                            });
+                    }
+                });
+
+            } catch (error) {
+                console.error('Failed to load or process index.json:', error);
+                catalogDiv.innerHTML = `<div class="error-message">Error loading asset catalog: ${error.message}</div>`;
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', fetchIndexAndDisplay);
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,18 @@
     </div>
 
     <script>
+        function escapeHTML(unsafe) {
+            if (unsafe === null || typeof unsafe === 'undefined') {
+                return '';
+            }
+            return unsafe
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#039;");
+        }
+
         async function fetchIndexAndDisplay() {
             const catalogDiv = document.getElementById('catalog');
             try {
@@ -85,7 +97,7 @@
                             <picture>
                                 ${webpSources ? `<source srcset="${webpSources}" type="image/webp">` : ''}
                                 ${jpgSources ? `<source srcset="${jpgSources}" type="image/jpeg">` : ''}
-                                ${fallbackSrc ? `<img src="${fallbackSrc}" alt="${asset.base_name || 'Processed Image'}">` : '<p>Image not available</p>'}
+                                ${fallbackSrc ? `<img src="${fallbackSrc}" alt="${escapeHTML(asset.base_name || 'Processed Image')}">` : '<p>Image not available</p>'}
                             </picture>
                         `;
                     } else if (asset.outputs.type === 'video') {
@@ -102,38 +114,23 @@
 
                     let descriptionRenderedHtml = '<p>No description available.</p>';
                     if (asset.description_markdown_path) {
-                        // Fetch markdown content - this is a simplified approach
-                        // In a real app, you might pre-fetch or handle errors more gracefully
-                        fetch(`${rawPrefix}${asset.description_markdown_path}?t=${new Date().getTime()}`)
-                            .then(res => res.text())
-                            .then(md => {
-                                if (md && !md.startsWith("<!DOCTYPE html>")) { // Basic check if content is markdown
-                                   assetDiv.querySelector('.description').innerHTML = marked.parse(md);
-                                } else {
-                                   assetDiv.querySelector('.description').innerHTML = '<p>Could not load description.</p>';
-                                }
-                            })
-                            .catch(err => {
-                                console.error('Error fetching markdown:', err);
-                                assetDiv.querySelector('.description').innerHTML = '<p>Error loading description.</p>';
-                            });
-                        descriptionRenderedHtml = '<div class="description-loading">Loading description...</div>'; // Placeholder
+                        // Placeholder for description, will be filled by the fetch call after assetDiv is in DOM
+                        descriptionRenderedHtml = '<div class="description-loading">Loading description...</div>';
                     }
 
-
                     assetDiv.innerHTML = `
-                        <h2>${asset.base_name || 'Untitled Asset'}</h2>
+                        <h2>${escapeHTML(asset.base_name || 'Untitled Asset')}</h2>
                         ${mediaHTML}
                         <div class="description">
                             ${descriptionRenderedHtml}
                         </div>
                         <div class="asset-details">
-                            <p><strong>Source File:</strong> ${asset.source_file_path}</p>
-                            <p><strong>Source Hash:</strong> ${asset.source_hash}</p>
-                            ${asset.outputs.html_page_path ? `<p><strong>HTML Page:</strong> <a href="${rawPrefix}${asset.outputs.html_page_path}" target="_blank">${asset.outputs.html_page_path.replace('processed_media/', '')}</a></p>` : ''}
+                            <p><strong>Source File:</strong> ${escapeHTML(asset.source_file_path)}</p>
+                            <p><strong>Source Hash:</strong> ${escapeHTML(asset.source_hash)}</p>
+                            ${asset.outputs.html_page_path ? `<p><strong>HTML Page:</strong> <a href="${rawPrefix}${asset.outputs.html_page_path}" target="_blank">${escapeHTML(asset.outputs.html_page_path.replace('processed_media/', ''))}</a></p>` : ''}
                             <p><strong>Processed Steps:</strong></p>
                             <ul>
-                                ${asset.processed_steps && asset.processed_steps.length > 0 ? asset.processed_steps.map(step => `<li>${step}</li>`).join('') : '<li>None</li>'}
+                                ${asset.processed_steps && asset.processed_steps.length > 0 ? asset.processed_steps.map(step => `<li>${escapeHTML(step)}</li>`).join('') : '<li>None</li>'}
                             </ul>
                         </div>
                     `;


### PR DESCRIPTION
- Replace processed_flags/ with a central index.json to track processed assets, their source hash, processing steps, and output file paths.
- Modify process_file.py to read from and write to index.json.
- Update GitHub workflow to remove processed_flags and commit index.json.
- Create index.html at the root to load index.json and display a catalog of processed assets.
- index.html renders markdown descriptions to HTML and displays images/videos with appropriate source links based on raw GitHub URLs.